### PR TITLE
[Fix] Fix #12 and quotations in PasswordHistoryLength

### DIFF
--- a/app/src/main/java/com/bintianqi/owndroid/dpm/ApplicationManage.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/dpm/ApplicationManage.kt
@@ -196,7 +196,7 @@ private fun Home(navCtrl:NavHostController, pkgName: String){
         if(isDeviceOwner(myDpm)||isProfileOwner(myDpm)){
             SubPageItem(R.string.block_uninstall,"",R.drawable.delete_forever_fill0){navCtrl.navigate("BlockUninstall")}
         }
-        if(VERSION.SDK_INT>=30&&(isDeviceOwner(myDpm)||isProfileOwner(myDpm))){
+        if((VERSION.SDK_INT>=30&&isDeviceOwner(myDpm))||(VERSION.SDK_INT>=33&&isProfileOwner(myDpm))){
             SubPageItem(R.string.ucd,"",R.drawable.do_not_touch_fill0){navCtrl.navigate("UserControlDisabled")}
         }
         if(VERSION.SDK_INT>=23&&(isDeviceOwner(myDpm)||isProfileOwner(myDpm))){

--- a/app/src/main/java/com/bintianqi/owndroid/dpm/Password.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/dpm/Password.kt
@@ -449,13 +449,13 @@ private fun PasswordHistoryLength(){
     var ableToApply by remember{ mutableStateOf(inputContent!="") }
     Column(modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp).verticalScroll(rememberScrollState())){
         Spacer(Modifier.padding(vertical = 10.dp))
-        Text(text = stringResource(R.string.pwd_timeout), style = typography.headlineLarge)
+        Text(text = stringResource(R.string.pwd_history), style = typography.headlineLarge)
         Spacer(Modifier.padding(vertical = 5.dp))
-        Text(text= stringResource(R.string.pwd_timeout_desc))
+        Text(text= stringResource(R.string.pwd_history_desc))
         Spacer(Modifier.padding(vertical = 5.dp))
         OutlinedTextField(
             value = inputContent,
-            label = { Text(stringResource(R.string.time_unit_ms))},
+            label = { Text(stringResource(R.string.length))},
             onValueChange = {
                 inputContent = it
                 ableToApply = inputContent!=""

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -30,6 +30,7 @@
     <string name="unknown">未知</string>
     <string name="reset">重置</string>
     <string name="time_unit_ms">时间(ms)</string>
+    <string name="length">长度</string>
     <string name="none">无</string>
     <string name="no_logs">无日志</string>
     <string name="default_stringres">默认</string>
@@ -403,6 +404,7 @@
     <string name="max_time_to_lock_desc">超时后锁屏(毫秒)，0为由用户决定</string>
     <string name="pwd_timeout_desc">超时后用户需重新设置密码（毫秒），0为无限制</string>
     <string name="pwd_history">密码历史记录长度</string>
+    <string name="pwd_history_desc">用户无法设置指定历史范围内之前曾设置过的密码</string>
     <string name="password_complexity_none">无（允许不设密码）</string>
     <string name="password_complexity_low">低（允许图案和连续性）</string>
     <string name="password_complexity_medium">中（无连续性，至少4位）</string>
@@ -454,7 +456,7 @@
     <string name="dynamic_color">动态取色</string>
     <string name="dynamic_color_desc">安卓12+</string>
     <string name="about">关于</string>
-    <string name="about_desc">使用安卓的Device admin、Device owner 、Profile owner，全方位掌控你的设备</string>
+    <string name="about_desc">使用安卓的Device admin、Device owner、Profile owner，全方位掌控你的设备</string>
     <string name="user_guide">使用教程</string>
     <string name="source_code">源代码</string>
     <string name="blackTheme">纯黑夜间主题</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="unknown">Unknown</string>
     <string name="reset">Reset</string>
     <string name="time_unit_ms">Time(ms)</string>
+    <string name="length">Length</string>
     <string name="none">None</string>
     <string name="no_logs">No logs</string>
     <string name="default_stringres">Default</string>
@@ -417,6 +418,7 @@
     <string name="max_time_to_lock_desc">Enter 0 to allow user decision, unit: millisecond</string>
     <string name="pwd_timeout_desc">When reach this limit, user should set a new password. Enter 0 to allow user decision, unit: millisecond</string>
     <string name="pwd_history">Password history length</string>
+    <string name="pwd_history_desc">Historical passwords within the specified range cannot be set by user</string>
     <string name="password_complexity_none">None (No password allowed)</string>
     <string name="password_complexity_low">Low (Gesture password and characters repetition allowed)</string>
     <string name="password_complexity_medium">Medium (Repetition disallowed, 4 characters at least)</string>
@@ -468,7 +470,7 @@
     <string name="dynamic_color">Dynamic color</string>
     <string name="dynamic_color_desc">Android 12+</string>
     <string name="about">About</string>
-    <string name="about_desc">Use device admin, profile owner and device owner privilege to take full control of your device. </string>
+    <string name="about_desc">Use Device admin, Profile owner and Device owner privilege to take full control of your device. </string>
     <string name="user_guide">User guide</string>
     <string name="source_code">Source code</string>
     <string name="blackTheme">Black theme</string>


### PR DESCRIPTION
1. Make the display condition of UCD to
- Android SDK Version >= 30 && Device owner activated
or
- Android SDK Version >= 33 && Profile owner activated
in order to prevent issue #12 .

2. Fix quotations in func PasswordHistoryLength from `pwd_timeout` --> `pwd_history`.