### PR TITLE
[Fix] Add androidx.fragment to dependencies to solve #25

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,5 @@ dependencies {
     implementation(libs.shizuku.provider)
     implementation(libs.shizuku.api)
     implementation(libs.androidx.biometric)
+    implementation(libs.androidx.fragment)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ material3 = "1.2.1"
 accompanist-drawablepainter = "0.35.0-alpha"
 shizuku = "13.1.5"
 biometric = "1.2.0-alpha05"
+fragment = "1.8.0-beta01"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
@@ -21,6 +22,7 @@ androidx-biometric = { group = "androidx.biometric", name = "biometric", version
 
 shizuku-provider = { module = "dev.rikka.shizuku:provider", version.ref = "shizuku" }
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "fragment" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
不是很理解这个问题到底是什么原因导致的, 如果说是没有引入 androidx.fragment 库, v5.3 前也没有引入, 但跑的好好的。难道 `context.registerForActivityResult` 会在使用 Fragment / 不使用 Fragment 的情况下采取不同的逻辑实现? 这好像是唯一的可能性了。

不懂。