### PR TITLE
[Fix / CI] Build release & debug APK in one go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,17 +26,14 @@ jobs:
       - name: Grant execution permission to Gradle Wrapper
         run: chmod +x gradlew
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug
+      - name: Build APK
+        run: ./gradlew build
 
       - name: Upload Debug APK
         uses: actions/upload-artifact@v4
         with:
           name: OwnDroid-CI-${{ env.SHORT_SHA }}-debug-testkey.apk
           path: app/build/outputs/apk/debug/app-debug.apk
-
-      - name: Build Release APK
-        run: ./gradlew assembleRelease
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
OwnDroid CI now use separated build command for `debug` & `release` APK, this will cause unnecessary waste of time & resource. In fact, using `gradlew build` will build `debug` & `release` at the same time, to reduce time costs.