### PR TITLE
fix: managed configurations key search

### DIFF
--- a/app/src/main/java/com/bintianqi/owndroid/dpm/Applications.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/dpm/Applications.kt
@@ -1024,7 +1024,7 @@ fun ManagedConfigurationScreen(
         restrictions
     } else {
         restrictions.filter {
-            it.key.contentEquals(searchKeyword, true) ||
+            it.key.contains(searchKeyword, true) ||
                     it.title?.contains(searchKeyword, true) ?: true
         }
     }


### PR DESCRIPTION
Use contains instead of contentEqual for managed configurations search.

Ref:
- https://github.com/BinTianqi/OwnDroid/discussions/198#discussioncomment-15079698