### PR TITLE
fix: lock task mode setOngoing(true) + FOREGROUND_SERVICE_IMMEDIATE

### DIFF
--- a/app/src/main/java/com/bintianqi/owndroid/LockTaskService.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/LockTaskService.kt
@@ -48,6 +48,7 @@ class LockTaskService: Service() {
             .setSmallIcon(R.drawable.lock_fill0)
             .addAction(NotificationCompat.Action.Builder(null, getString(R.string.stop), pendingIntent).build())
             .setOngoing(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
         ServiceCompat.startForeground(
             this, NotificationType.LockTaskMode.id, notification,


### PR DESCRIPTION
@BinTianqi - Note that on Android 14, even when using `.setOngoing(true)` for persistence, the notification can still be dismissed (with some exceptions, e.g. device owner):

- https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications

    <img width="90%" alt="android-14-changes" src="https://github.com/user-attachments/assets/39287822-c8ab-4fc2-a66a-6906e3aac946" />

There is a potential workaround listed here to keep the notification persistent:
- https://stackoverflow.com/a/77080872/22324694

---

EDIT: also added `NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE` so that the notification shows immediately (since the launched app will likely be active for more than a few seconds, the default delay to avoid flicker is not needed).