### PR TITLE
feat: lock task mode clear task on start

### DIFF
--- a/app/src/main/java/com/bintianqi/owndroid/MyViewModel.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/MyViewModel.kt
@@ -874,7 +874,7 @@ class MyViewModel(application: Application): AndroidViewModel(application) {
         getLockTaskPackages()
     }
     @RequiresApi(28)
-    fun startLockTaskMode(packageName: String, activity: String): Boolean {
+    fun startLockTaskMode(packageName: String, activity: String, clearTask: Boolean): Boolean {
         if (!DPM.isLockTaskPermitted(packageName)) {
             val list = lockTaskPackages.value.map { it.name } + packageName
             DPM.setLockTaskPackages(DAR, list.toTypedArray())
@@ -885,7 +885,10 @@ class MyViewModel(application: Application): AndroidViewModel(application) {
             Intent().setComponent(ComponentName(packageName, activity))
         } else PM.getLaunchIntentForPackage(packageName)
         if (intent != null) {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK
+                    or (if (clearTask) Intent.FLAG_ACTIVITY_CLEAR_TASK else 0)
+            )
             application.startActivity(intent, options.toBundle())
             application.startForegroundService(Intent(application, LockTaskService::class.java))
             return true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,4 +732,5 @@
     <string name="activate_method">Activate method</string>
     <string name="adb_command">ADB command</string>
     <string name="owndroid_warning">This app uses Device owner or Profile owner privileges. These privileges are extremely dangerous, please use them with caution. If used improperly, they may result in severe losses. The developers will not be responsible for this.</string>
+    <string name="lock_task_mode_start_clear_task">Clear task (start fresh)</string>
 </resources>


### PR DESCRIPTION
Add a checkbox option (default true) to apply [Intent.FLAG_ACTIVITY_CLEAR_TASK](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_TASK) when starting lock task mode:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a62657f6-c850-4d14-b97d-39bcdd774ea0" />

This is because, if the activity is already started, lock task mode will be turned on when starting. Video demo:

[owndroid-start-lock-task-clear-task.webm](https://github.com/user-attachments/assets/fd9e1c00-1f1b-4448-bdd0-8e7a0c0eabd2)
