### PR TITLE
fix: add EXTRA_PROVISIONING_MODE and PROVISIONING_MODE_FULLY_MANAGED_DEVICE to intent

### DIFF
--- a/app/src/main/java/com/bintianqi/owndroid/activity/ProvisioningActivity.kt
+++ b/app/src/main/java/com/bintianqi/owndroid/activity/ProvisioningActivity.kt
@@ -1,5 +1,6 @@
 package com.bintianqi.owndroid.activity
 
+import android.app.admin.DevicePolicyManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -23,7 +24,12 @@ class ProvisioningActivity: ComponentActivity() {
             val theme by myApp.container.themeState.collectAsState()
             OwnDroidTheme(theme) {
                 ProvisioningScreen(vm.params) {
-                    setResult(RESULT_OK, vm.buildResultIntent(it))
+                    val intent = vm.buildResultIntent(it)
+                    intent.putExtra(
+                        DevicePolicyManager.EXTRA_PROVISIONING_MODE,
+                        DevicePolicyManager.PROVISIONING_MODE_FULLY_MANAGED_DEVICE
+                    )
+                    setResult(RESULT_OK, intent)
                     finish()
                 }
             }


### PR DESCRIPTION
Ref:

- https://github.com/BinTianqi/OwnDroid/discussions/187#discussioncomment-16074765

I have this in my own app here (likely from following either Test DPC or Dhizuku's example):

- https://github.com/nktnet1/webview-kiosk/blob/d851de813d7dfebf48f961f335180f10f6995932/app/src/main/java/uk/nktnet/webviewkiosk/activities/ProvisioningActivity.kt#L16-L19

---

Superseded by https://github.com/BinTianqi/OwnDroid/commit/ad8143bec9e4b6e2e89e78c1162740b513040ea4